### PR TITLE
Small optimization save gas

### DIFF
--- a/contracts/modules/LoanClosings/LoanClosingsBase.sol
+++ b/contracts/modules/LoanClosings/LoanClosingsBase.sol
@@ -51,7 +51,6 @@ contract LoanClosingsBase is State, LoanClosingsEvents, VaultController, Interes
         LoanParams storage loanParamsLocal = loanParams[loanLocal.loanParamsId];
 
         require(loanLocal.active, "loan is closed");
-        require(loanParamsLocal.id != 0, "loanParams not exists");
 
         (uint256 currentMargin, uint256 collateralToLoanRate) = IPriceFeeds(priceFeeds).getCurrentMargin(
             loanParamsLocal.loanToken,
@@ -162,7 +161,6 @@ contract LoanClosingsBase is State, LoanClosingsEvents, VaultController, Interes
         LoanParams storage loanParamsLocal = loanParams[loanLocal.loanParamsId];
 
         require(loanLocal.active, "loan is closed");
-        require(loanParamsLocal.id != 0, "loanParams not exists");
         require(
             block.timestamp > loanLocal.endTimestamp.sub(3600),
             "healthy position"
@@ -505,7 +503,6 @@ contract LoanClosingsBase is State, LoanClosingsEvents, VaultController, Interes
             delegatedManagers[loanLocal.id][msg.sender],
             "unauthorized"
         );
-        require(loanParamsLocal.id != 0, "loanParams not exists");
     }
 
     function _settleInterestToPrincipal(

--- a/contracts/modules/LoanClosings/LoanClosingsBase.sol
+++ b/contracts/modules/LoanClosings/LoanClosingsBase.sol
@@ -311,7 +311,8 @@ contract LoanClosingsBase is State, LoanClosingsEvents, VaultController, Interes
         Loan storage loanLocal = loans[loanId];
         LoanParams storage loanParamsLocal = loanParams[loanLocal.loanParamsId];
         _checkAuthorized(
-            loanId
+            loanLocal,
+            loanParamsLocal
         );
 
         // can't close more than the full principal
@@ -383,7 +384,8 @@ contract LoanClosingsBase is State, LoanClosingsEvents, VaultController, Interes
         Loan storage loanLocal = loans[loanId];
         LoanParams storage loanParamsLocal = loanParams[loanLocal.loanParamsId];
         _checkAuthorized(
-            loanId
+            loanLocal,
+            loanParamsLocal
         );
 
         swapAmount = swapAmount > loanLocal.collateral ?
@@ -490,12 +492,11 @@ contract LoanClosingsBase is State, LoanClosingsEvents, VaultController, Interes
     }
 
     function _checkAuthorized(
-        bytes32 loanId)
+        Loan memory loanLocal,
+        LoanParams memory loanParamsLocal)
         internal
         view
     {
-        Loan storage loanLocal = loans[loanId];
-        LoanParams storage loanParamsLocal = loanParams[loanLocal.loanParamsId];
         require(loanLocal.active, "loan is closed");
         require(
             msg.sender == loanLocal.borrower ||

--- a/contracts/modules/LoanClosings/LoanClosingsBase.sol
+++ b/contracts/modules/LoanClosings/LoanClosingsBase.sol
@@ -311,8 +311,7 @@ contract LoanClosingsBase is State, LoanClosingsEvents, VaultController, Interes
         Loan storage loanLocal = loans[loanId];
         LoanParams storage loanParamsLocal = loanParams[loanLocal.loanParamsId];
         _checkAuthorized(
-            loanLocal,
-            loanParamsLocal
+            loanId
         );
 
         // can't close more than the full principal
@@ -384,8 +383,7 @@ contract LoanClosingsBase is State, LoanClosingsEvents, VaultController, Interes
         Loan storage loanLocal = loans[loanId];
         LoanParams storage loanParamsLocal = loanParams[loanLocal.loanParamsId];
         _checkAuthorized(
-            loanLocal,
-            loanParamsLocal
+            loanId
         );
 
         swapAmount = swapAmount > loanLocal.collateral ?
@@ -492,11 +490,12 @@ contract LoanClosingsBase is State, LoanClosingsEvents, VaultController, Interes
     }
 
     function _checkAuthorized(
-        Loan memory loanLocal,
-        LoanParams memory loanParamsLocal)
+        bytes32 loanId)
         internal
         view
     {
+        Loan storage loanLocal = loans[loanId];
+        LoanParams storage loanParamsLocal = loanParams[loanLocal.loanParamsId];
         require(loanLocal.active, "loan is closed");
         require(
             msg.sender == loanLocal.borrower ||

--- a/contracts/modules/LoanClosings/LoanClosingsBase.sol
+++ b/contracts/modules/LoanClosings/LoanClosingsBase.sol
@@ -311,8 +311,9 @@ contract LoanClosingsBase is State, LoanClosingsEvents, VaultController, Interes
         Loan storage loanLocal = loans[loanId];
         LoanParams storage loanParamsLocal = loanParams[loanLocal.loanParamsId];
         _checkAuthorized(
-            loanLocal,
-            loanParamsLocal
+            loanLocal.id,
+            loanLocal.active,
+            loanLocal.borrower
         );
 
         // can't close more than the full principal
@@ -384,8 +385,9 @@ contract LoanClosingsBase is State, LoanClosingsEvents, VaultController, Interes
         Loan storage loanLocal = loans[loanId];
         LoanParams storage loanParamsLocal = loanParams[loanLocal.loanParamsId];
         _checkAuthorized(
-            loanLocal,
-            loanParamsLocal
+            loanLocal.id,
+            loanLocal.active,
+            loanLocal.borrower
         );
 
         swapAmount = swapAmount > loanLocal.collateral ?
@@ -492,15 +494,16 @@ contract LoanClosingsBase is State, LoanClosingsEvents, VaultController, Interes
     }
 
     function _checkAuthorized(
-        Loan memory loanLocal,
-        LoanParams memory loanParamsLocal)
+        bytes32 _id,
+        bool _active,
+        address _borrower)
         internal
         view
     {
-        require(loanLocal.active, "loan is closed");
+        require(_active, "loan is closed");
         require(
-            msg.sender == loanLocal.borrower ||
-            delegatedManagers[loanLocal.id][msg.sender],
+            msg.sender == _borrower ||
+            delegatedManagers[_id][msg.sender],
             "unauthorized"
         );
     }


### PR DESCRIPTION
Before
>>> tx = accounts[0].deploy(LoanClosings)                                                                                                                                                                          
Transaction sent: 0x921b6d5f8becd474d8ff2bcad03f03cde3e0d461ca69c96234eff4c84b2e1b1d
  Gas price: 0.0 gwei   Gas limit: 8000000
  LoanClosings.constructor confirmed - Block: 2   `Gas used: 5174491 (64.68%)`
  LoanClosings deployed at: 0x602C71e4DAC47a042Ee7f46E0aee17F94A3bA0B6

After:
>>> tx = accounts[0].deploy(LoanClosings)                                                                                                                                                                          
Transaction sent: 0xf43f4b57219bd8078359a65a4ad95689f50edf6be693b3d5e74c655a3f5f3ba3
  Gas price: 0.0 gwei   Gas limit: 8000000
  LoanClosings.constructor confirmed - Block: 3   `Gas used: 4982018 (62.28%)`
  LoanClosings deployed at: 0xE7eD6747FaC5360f88a2EFC03E00d25789F69291

