### PR TITLE
Earn reward event missing loanid

### DIFF
--- a/contracts/modules/LoanOpenings/LoanOpenings.sol
+++ b/contracts/modules/LoanOpenings/LoanOpenings.sol
@@ -324,7 +324,7 @@ contract LoanOpenings is State, LoanOpeningsEvents, VaultController, InterestUse
             // sentValues[3] is repurposed to hold loanToCollateralSwapRate to avoid stack too deep error
             uint256 receivedAmount;
             (receivedAmount,,sentValues[3]) = _loanSwap(
-                loanId,
+                loanLocal.id,
                 loanParamsLocal.loanToken,
                 loanParamsLocal.collateralToken,
                 sentAddresses[1], // borrower

--- a/tests/loan-openings/test_LoanOpeningsEvents.py
+++ b/tests/loan-openings/test_LoanOpeningsEvents.py
@@ -1,8 +1,9 @@
 #!/usr/bin/python3
 
 import pytest
-from brownie import Wei, reverts 
+from brownie import Wei, reverts
 from helpers import getLoanId, setupLoanPool
+
 
 @pytest.fixture(scope="module")
 def LinkDaiBorrowParamsId(Constants, LINK, DAI, bzx, accounts, WETH):
@@ -14,10 +15,11 @@ def LinkDaiBorrowParamsId(Constants, LINK, DAI, bzx, accounts, WETH):
         "collateralToken": LINK.address,
         "minInitialMargin": 20e18,
         "maintenanceMargin": 15e18,
-        "fixedLoanTerm": "0", # torque loan
+        "fixedLoanTerm": "0",  # torque loan
     }
     tx = bzx.setupLoanParams([list(loanParams.values())])
     return tx.events["LoanParamsIdSetup"][0]["id"]
+
 
 @pytest.fixture(scope="module")
 def LinkDaiTradeParamsId(Constants, LINK, DAI, bzx, accounts, WETH):
@@ -29,29 +31,16 @@ def LinkDaiTradeParamsId(Constants, LINK, DAI, bzx, accounts, WETH):
         "collateralToken": LINK.address,
         "minInitialMargin": 20e18,
         "maintenanceMargin": 15e18,
-        "fixedLoanTerm": "2419200" # 28 days
+        "fixedLoanTerm": "2419200"  # 28 days
     }
     tx = bzx.setupLoanParams([list(loanParams.values())])
     return tx.events["LoanParamsIdSetup"][0]["id"]
 
-@pytest.fixture(scope="module")
-def linkDaiMarginParamsId(Constants, LINK, DAI, bzx, accounts):
-    loanParams = {
-        "id": "0x0",
-        "active": False,
-        "owner": Constants["ZERO_ADDRESS"],
-        "loanToken": DAI.address,
-        "collateralToken": LINK.address,
-        "minInitialMargin": 20e18,
-        "maintenanceMargin": 15e18,
-        "fixedLoanTerm": "2419200" # 28 days
-    }
-    tx = bzx.setupLoanParams([list(loanParams.values())])
-    return tx.events["LoanParamsIdSetup"][0]["id"]
 
 @pytest.fixture(scope="module")
 def loanId_LINK_DAI(Constants, bzx, DAI, LINK, accounts, web3, LinkDaiBorrowParamsId):
     return getLoanId(Constants, bzx, DAI, LINK, accounts, web3, LinkDaiBorrowParamsId)
+
 
 @pytest.fixture(scope="module")
 def setup(Constants, bzx, LINK, DAI, accounts):
@@ -63,7 +52,7 @@ def setup(Constants, bzx, LINK, DAI, accounts):
     DAI.mint(
         bzx.address,
         loanTokenSent,
-        { "from": accounts[0] }
+        {"from": accounts[0]}
     )
 
     collateralTokenSent = bzx.getRequiredCollateral(
@@ -77,74 +66,78 @@ def setup(Constants, bzx, LINK, DAI, accounts):
     LINK.mint(
         bzx.address,
         collateralTokenSent,
-        { "from": accounts[0] }
+        {"from": accounts[0]}
     )
     return collateralTokenSent
 
+
 def test_borrowOrTradeFromPoolBorrowEvent(Constants, bzx, accounts, LinkDaiBorrowParamsId, DAI, LINK, setup):
     tx = bzx.borrowOrTradeFromPool(
-        LinkDaiBorrowParamsId, #loanParamsId
-        "0", # loanId - starts a new loan
-        True, # isTorqueLoan,
-        50e18, # initialMargin
+        LinkDaiBorrowParamsId,  # loanParamsId
+        "0",  # loanId - starts a new loan
+        True,  # isTorqueLoan,
+        50e18,  # initialMargin
         [
-            accounts[2], # lender
-            accounts[1], # borrower
-            accounts[1], # receiver
-            Constants["ZERO_ADDRESS"], # manager
+            accounts[2],  # lender
+            accounts[1],  # borrower
+            accounts[1],  # receiver
+            Constants["ZERO_ADDRESS"],  # manager
         ],
         [
-            5e18, # newRate (5%)
-            101e18, # newPrincipal
-            1e18, # torqueInterest
-            1e18, # loanTokenSent
-            setup # collateralTokenSent
+            5e18,  # newRate (5%)
+            101e18,  # newPrincipal
+            1e18,  # torqueInterest
+            1e18,  # loanTokenSent
+            setup  # collateralTokenSent
         ],
-        b'', # loanDataBytes
-        { "from": accounts[1] }
+        b'',  # loanDataBytes
+        {"from": accounts[1]}
     )
 
     tx.info()
 
     borrowEvent = tx.events["Borrow"][0]
     assert(borrowEvent["user"] == accounts[1])
-    assert(borrowEvent["lender"] == accounts[2]) 
+    assert(borrowEvent["lender"] == accounts[2])
     assert(borrowEvent["loanToken"] == DAI)
     assert(borrowEvent["collateralToken"] == LINK)
-    assert(borrowEvent["newPrincipal"] == 101e18) 
+    assert(borrowEvent["newPrincipal"] == 101e18)
+
 
 def test_borrowOrTradeFromPoolTradeEvent(Constants, bzx, accounts, LinkDaiTradeParamsId, DAI, LINK, setup):
     tx = bzx.borrowOrTradeFromPool(
-        LinkDaiTradeParamsId, #loanParamsId
-        "0", # loanId - starts a new loan
-        False, # isTorqueLoan,
-        50e18, # initialMargin
+        LinkDaiTradeParamsId,  # loanParamsId
+        "0",  # loanId - starts a new loan
+        False,  # isTorqueLoan,
+        50e18,  # initialMargin
         [
-            accounts[2], # lender
-            accounts[1], # borrower
-            accounts[1], # receiver
-            Constants["ZERO_ADDRESS"], # manager
+            accounts[2],  # lender
+            accounts[1],  # borrower
+            accounts[1],  # receiver
+            Constants["ZERO_ADDRESS"],  # manager
         ],
         [
-            5e18, # newRate (5%)
-            101e18, # newPrincipal
-            0, # torqueInterest
-            1e18, # loanTokenSent
-            setup # collateralTokenSent
+            5e18,  # newRate (5%)
+            101e18,  # newPrincipal
+            0,  # torqueInterest
+            1e18,  # loanTokenSent
+            setup  # collateralTokenSent
         ],
-        b'', # loanDataBytes
-        { "from": accounts[1] }
+        b'',  # loanDataBytes
+        {"from": accounts[1]}
     )
     tx.info()
 
     borrowEvent = tx.events["Trade"][0]
     assert(borrowEvent["user"] == accounts[1])
-    assert(borrowEvent["lender"] == accounts[2]) 
+    assert(borrowEvent["lender"] == accounts[2])
     assert(borrowEvent["loanToken"] == DAI)
     assert(borrowEvent["collateralToken"] == LINK)
 
+
 def test_setDelegatedManagerSetEvent(Constants, bzx, accounts, loanId_LINK_DAI):
-    tx = bzx.setDelegatedManager(loanId_LINK_DAI, accounts[2], True, {"from": accounts[1]})
+    tx = bzx.setDelegatedManager(
+        loanId_LINK_DAI, accounts[2], True, {"from": accounts[1]})
     tx.info()
     delegatedManagerSet = tx.events["DelegatedManagerSet"][0]
     assert(delegatedManagerSet["loanId"] == loanId_LINK_DAI)
@@ -161,7 +154,7 @@ def test_EarnRewardEvent(Constants, bzx, accounts, LinkDaiTradeParamsId, LINK, D
     DAI.mint(
         bzx.address,
         loanTokenSent,
-        { "from": accounts[0] }
+        {"from": accounts[0]}
     )
     collateralTokenSent = bzx.getRequiredCollateral(
         DAI.address,
@@ -173,29 +166,29 @@ def test_EarnRewardEvent(Constants, bzx, accounts, LinkDaiTradeParamsId, LINK, D
     LINK.mint(
         bzx.address,
         collateralTokenSent,
-        { "from": accounts[0] }
+        {"from": accounts[0]}
     )
 
     tx = bzx.borrowOrTradeFromPool(
-        LinkDaiTradeParamsId, #loanParamsId
-        "0", # loanId
-        False, # isTorqueLoan,
-        100e18, # initialMargin
+        LinkDaiTradeParamsId,  # loanParamsId
+        "0",  # loanId
+        False,  # isTorqueLoan,
+        100e18,  # initialMargin
         [
-            accounts[2], # lender
-            accounts[1], # borrower
-            accounts[1], # receiver
-            Constants["ZERO_ADDRESS"], # manager
+            accounts[2],  # lender
+            accounts[1],  # borrower
+            accounts[1],  # receiver
+            Constants["ZERO_ADDRESS"],  # manager
         ],
         [
-            5e18, # newRate (5%)
-            loanTokenSent, # newPrincipal
-            0, # torqueInterest
-            loanTokenSent, # loanTokenSent
-            collateralTokenSent # collateralTokenSent
+            5e18,  # newRate (5%)
+            loanTokenSent,  # newPrincipal
+            0,  # torqueInterest
+            loanTokenSent,  # loanTokenSent
+            collateralTokenSent  # collateralTokenSent
         ],
-        b'', # loanDataBytes
-        { "from": accounts[1] }
+        b'',  # loanDataBytes
+        {"from": accounts[1]}
     )
     tradeEvent = tx.events['Trade'][0]
     assert(tradeEvent['user'] == accounts[1])
@@ -206,7 +199,10 @@ def test_EarnRewardEvent(Constants, bzx, accounts, LinkDaiTradeParamsId, LINK, D
     loanId = tradeEvent['loanId']
 
     payTradingFeeEvent = tx.events[0][0]
-    assert(payTradingFeeEvent['topic1'] == '0xb23479169712c443e6b00fb0cec3506a5f5926f541df4243d313e11c8c5c71ed') # kessak of PayTradinfFee event
-    assert('0X'+ payTradingFeeEvent['topic2'][26:66] == accounts[1])
-    assert(('0X'+ payTradingFeeEvent['topic3'][26:66].upper()) == DAI.address.upper())
+    # kessak of PayTradinfFee event
+    assert(payTradingFeeEvent['topic1'] ==
+           '0xb23479169712c443e6b00fb0cec3506a5f5926f541df4243d313e11c8c5c71ed')
+    assert('0X' + payTradingFeeEvent['topic2'][26:66] == accounts[1])
+    assert(('0X' + payTradingFeeEvent['topic3']
+            [26:66].upper()) == DAI.address.upper())
     assert(payTradingFeeEvent['topic4'] == loanId)

--- a/tests/loan-openings/test_LoanOpeningsEvents.py
+++ b/tests/loan-openings/test_LoanOpeningsEvents.py
@@ -35,6 +35,21 @@ def LinkDaiTradeParamsId(Constants, LINK, DAI, bzx, accounts, WETH):
     return tx.events["LoanParamsIdSetup"][0]["id"]
 
 @pytest.fixture(scope="module")
+def linkDaiMarginParamsId(Constants, LINK, DAI, bzx, accounts):
+    loanParams = {
+        "id": "0x0",
+        "active": False,
+        "owner": Constants["ZERO_ADDRESS"],
+        "loanToken": DAI.address,
+        "collateralToken": LINK.address,
+        "minInitialMargin": 20e18,
+        "maintenanceMargin": 15e18,
+        "fixedLoanTerm": "2419200" # 28 days
+    }
+    tx = bzx.setupLoanParams([list(loanParams.values())])
+    return tx.events["LoanParamsIdSetup"][0]["id"]
+
+@pytest.fixture(scope="module")
 def loanId_LINK_DAI(Constants, bzx, DAI, LINK, accounts, web3, LinkDaiBorrowParamsId):
     return getLoanId(Constants, bzx, DAI, LINK, accounts, web3, LinkDaiBorrowParamsId)
 
@@ -136,3 +151,62 @@ def test_setDelegatedManagerSetEvent(Constants, bzx, accounts, loanId_LINK_DAI):
     assert(delegatedManagerSet["delegator"] == accounts[1])
     assert(delegatedManagerSet["delegated"] == accounts[2])
     assert(delegatedManagerSet["isActive"])
+
+
+def test_EarnRewardEvent(Constants, bzx, accounts, LinkDaiTradeParamsId, LINK, DAI):
+
+    setupLoanPool(Constants, bzx, accounts[1], accounts[2])
+    loanTokenSent = 100e18
+
+    DAI.mint(
+        bzx.address,
+        loanTokenSent,
+        { "from": accounts[0] }
+    )
+    collateralTokenSent = bzx.getRequiredCollateral(
+        DAI.address,
+        LINK.address,
+        loanTokenSent,
+        100e18,
+        False
+    )
+    LINK.mint(
+        bzx.address,
+        collateralTokenSent,
+        { "from": accounts[0] }
+    )
+
+    tx = bzx.borrowOrTradeFromPool(
+        LinkDaiTradeParamsId, #loanParamsId
+        "0", # loanId
+        False, # isTorqueLoan,
+        100e18, # initialMargin
+        [
+            accounts[2], # lender
+            accounts[1], # borrower
+            accounts[1], # receiver
+            Constants["ZERO_ADDRESS"], # manager
+        ],
+        [
+            5e18, # newRate (5%)
+            loanTokenSent, # newPrincipal
+            0, # torqueInterest
+            loanTokenSent, # loanTokenSent
+            collateralTokenSent # collateralTokenSent
+        ],
+        b'', # loanDataBytes
+        { "from": accounts[1] }
+    )
+    tradeEvent = tx.events['Trade'][0]
+    assert(tradeEvent['user'] == accounts[1])
+    assert(tradeEvent['lender'] == accounts[2])
+    assert(tradeEvent['collateralToken'] == LINK.address)
+    assert(tradeEvent['loanToken'] == DAI.address)
+
+    loanId = tradeEvent['loanId']
+
+    payTradingFeeEvent = tx.events[0][0]
+    assert(payTradingFeeEvent['topic1'] == '0xb23479169712c443e6b00fb0cec3506a5f5926f541df4243d313e11c8c5c71ed') # kessak of PayTradinfFee event
+    assert('0X'+ payTradingFeeEvent['topic2'][26:66] == accounts[1])
+    assert(('0X'+ payTradingFeeEvent['topic3'][26:66].upper()) == DAI.address.upper())
+    assert(payTradingFeeEvent['topic4'] == loanId)


### PR DESCRIPTION
Its that bug we disscussed:

```
Tom Bean - bZx.network / fulcrum.trade, [30.09.20 01:24]
ok, i see a bug with that.. LoanOpenings.sol L327, will be 0x0000 if it's a new loan, instead loanLocal.id should be passed.

Tom Bean - bZx.network / fulcrum.trade, [30.09.20 01:24]
that's problem the cause

Tom Bean - bZx.network / fulcrum.trade, [30.09.20 01:24]
I bet this just happens with margin trades that are new loans

Tom Bean - bZx.network / fulcrum.trade, [30.09.20 01:25]
luckily, this isn't a security risk, just an informational bug

Tom Bean - bZx.network / fulcrum.trade, [30.09.20 01:25]
can you test and do a PR when you get time.
```