### PR TITLE
Wvbzrx proxy2

### DIFF
--- a/contracts/protocoltoken/VBZRXWrapper.sol
+++ b/contracts/protocoltoken/VBZRXWrapper.sol
@@ -31,7 +31,7 @@ contract VBZRXWrapper {
     event Approval(address indexed owner, address indexed spender, uint256 value);
     event Transfer(address indexed src, address indexed dst, uint256 value);
     event Deposit(address indexed dst, uint256 value);
-    event Withdrawal(address indexed src, uint256 value);
+    event Withdraw(address indexed src, uint256 value);
     event Claim(address indexed owner, uint256 value);
 
     // --- Token ---
@@ -157,6 +157,6 @@ contract VBZRXWrapper {
         totalSupply -= value;
         vBZRX.transfer(msg.sender, value);
         emit Transfer(msg.sender, address(0), value);
-        emit Withdrawal(msg.sender, value);
+        emit Withdraw(msg.sender, value);
     }
 }

--- a/contracts/protocoltoken/VBZRXWrapper.sol
+++ b/contracts/protocoltoken/VBZRXWrapper.sol
@@ -7,10 +7,14 @@ pragma solidity 0.5.17;
 
 import "../openzeppelin/SafeMath.sol";
 import "../interfaces/IVestingToken.sol";
+import "../openzeppelin/Ownable.sol";
 
 
-contract VBZRXWrapper {
+contract VBZRXWrapper is Ownable {
     using SafeMath for uint256;
+    //
+
+    address public implementation;
 
     // --- ERC20 Data ---
     string  public constant name     = "Wrapped vBZRX";

--- a/testsmainnet/vBzrxWrapper/test_wvbzrx.py
+++ b/testsmainnet/vBzrxWrapper/test_wvbzrx.py
@@ -105,7 +105,7 @@ def test_events(requireMainnetFork, bzrx, vbzrx, chain, accounts, wrapper):
     depositEvent = tx2.events['Deposit']
     assert depositEvent['value'] == INITIAL_LP_TOKEN_ACCOUNT_AMOUNT
     tx3 = wrapper.exit({"from": account1})
-    withdrawal = tx3.events['Withdrawal']
+    withdrawal = tx3.events['Withdraw']
     assert withdrawal['value'] == INITIAL_LP_TOKEN_ACCOUNT_AMOUNT
 
 

--- a/testsmainnet/vBzrxWrapper/test_wvbzrx.py
+++ b/testsmainnet/vBzrxWrapper/test_wvbzrx.py
@@ -1,24 +1,29 @@
 import pytest
 from brownie import Contract, network, reverts
 
-INITIAL_LP_TOKEN_ACCOUNT_AMOUNT = 100 * 10 ** 18;
+INITIAL_LP_TOKEN_ACCOUNT_AMOUNT = 200 * 10 ** 18;
+
 
 @pytest.fixture(scope="module")
 def requireMainnetFork():
     assert (network.show_active() == "mainnet-fork" or network.show_active() == "mainnet-fork-alchemy")
 
+
 @pytest.fixture(scope="module")
 def bzrx(accounts, interface):
-    return Contract.from_abi("bzrx", address="0x56d811088235F11C8920698a204A5010a788f4b3", abi=interface.ERC20.abi, owner=accounts[0])
+    return Contract.from_abi("bzrx", address="0x56d811088235F11C8920698a204A5010a788f4b3", abi=interface.ERC20.abi,
+                             owner=accounts[0])
+
 
 @pytest.fixture(scope="module")
 def vbzrx(accounts, BZRXVestingToken):
-    return  Contract.from_abi("bzrx", address="0xb72b31907c1c95f3650b64b2469e08edacee5e8f", abi=BZRXVestingToken.abi, owner=accounts[0])
+    return Contract.from_abi("bzrx", address="0xb72b31907c1c95f3650b64b2469e08edacee5e8f", abi=BZRXVestingToken.abi,
+                             owner=accounts[0])
+
 
 @pytest.fixture(scope="module")
 def wrapper(accounts, VBZRXWrapper):
-    return  VBZRXWrapper.deploy({"from": accounts[0]})
-
+    return VBZRXWrapper.deploy({"from": accounts[0]})
 
 
 vbzrxMajorAddress = "0x29dce6d3039644c66c456998de3bd723b141ff16";
@@ -27,49 +32,55 @@ def test_mainflow(requireMainnetFork, bzrx, vbzrx, chain, accounts, wrapper):
     account1 = accounts[1]
     account2 = accounts[2]
     vbzrxBalanceBefore = vbzrx.balanceOf(account1)
-    bzrxBalanceBefore = bzrx.balanceOf(account1)
+    bzrxBalanceBefore1 = bzrx.balanceOf(account1)
+    bzrxBalanceBefore2 = bzrx.balanceOf(account2)
     tx1 = vbzrx.transfer(account1, INITIAL_LP_TOKEN_ACCOUNT_AMOUNT, {"from": vbzrxMajorAddress})
     vbzrxBalanceAfter = vbzrxBalanceBefore + INITIAL_LP_TOKEN_ACCOUNT_AMOUNT
     assert vbzrx.balanceOf(account1) == vbzrxBalanceAfter
-    assert vbzrx.vestedBalanceOf(account1)  == 0
-    assert bzrxBalanceBefore == 0
+    assert vbzrx.vestedBalanceOf(account1) == 0
     chain.mine()
 
     vbzrx.approve(wrapper, vbzrx.balanceOf(account1), {"from": account1})
     depositAmount = vbzrx.balanceOf(account1);
     vestedBalance = vbzrx.vestedBalanceOf(account1);
-    assert vestedBalance  > 0
-
+    assert vestedBalance > 0
     tx2 = wrapper.deposit(depositAmount, {"from": account1})
-    assert vbzrx.vestedBalanceOf(account1)  == 0
-    assert bzrx.balanceOf(account1)  >= vestedBalance
-    assert bzrx.balanceOf(account1) > 0
+    assert vbzrx.vestedBalanceOf(account1) == 0
+    assert bzrx.balanceOf(account1) >= vestedBalance + bzrxBalanceBefore1
+    assert bzrx.balanceOf(account1) > bzrxBalanceBefore1
     assert wrapper.claimable(account1) == 0
+
     chain.mine()
     assert wrapper.claimable(account1) > 0
 
     tx3 = wrapper.transfer(account2, depositAmount, {"from": account1})
-    assert wrapper.balanceOf(account1)  == 0
+    assert wrapper.balanceOf(account1) == 0
     assert wrapper.balanceOf(account2) == INITIAL_LP_TOKEN_ACCOUNT_AMOUNT
     assert wrapper.claimable(account1) == 0
     assert wrapper.claimable(account2) > 0
-    assert vbzrx.vestedBalanceOf(account2)  == 0
-    assert vbzrx.vestedBalanceOf(account1)  == 0
+    assert vbzrx.vestedBalanceOf(account2) == 0
+    assert vbzrx.vestedBalanceOf(account1) == 0
     wrapper.claim({"from": account2});
-    assert bzrx.balanceOf(account2)  > 0
+    assert bzrx.balanceOf(account2) > bzrxBalanceBefore2
+    assert wrapper.claimable(account2) == 0
 
-    tx4 = wrapper.withdraw(depositAmount,  {"from": account2})
+
+    tx4 = wrapper.withdraw(depositAmount, {"from": account2})
     assert vbzrx.balanceOf(account2) == INITIAL_LP_TOKEN_ACCOUNT_AMOUNT
-    assert vbzrx.vestedBalanceOf(account2)  == 0
+    assert vbzrx.vestedBalanceOf(account2) == 0
+    claimable2 = wrapper.claimable(account2)
+    assert claimable2 > 0
     chain.mine()
+    assert wrapper.claimable(account2) == claimable2
+    wrapper.claim({"from": account2})
     assert vbzrx.vestedBalanceOf(account2)  > 0
-    assert wrapper.claimable(account2)  > 0
+    assert wrapper.claimable(account2)  == 0
+    assert vbzrx.vestedBalanceOf(account2) > 0
+
 
 
 def test_exit(requireMainnetFork, bzrx, vbzrx, chain, accounts, wrapper):
     account1 = accounts[3]
-    vbzrxBalanceBefore = vbzrx.balanceOf(account1)
-    bzrxBalanceBefore = bzrx.balanceOf(account1)
     tx1 = vbzrx.transfer(account1, INITIAL_LP_TOKEN_ACCOUNT_AMOUNT, {"from": vbzrxMajorAddress})
     vbzrx.approve(wrapper, vbzrx.balanceOf(account1), {"from": account1})
     depositAmount = vbzrx.balanceOf(account1);
@@ -84,19 +95,198 @@ def test_exit(requireMainnetFork, bzrx, vbzrx, chain, accounts, wrapper):
     assert vbzrx.balanceOf(account1) == INITIAL_LP_TOKEN_ACCOUNT_AMOUNT
     assert wrapper.balanceOf(account1) == 0
 
-def test_deposit_more_than_have(requireMainnetFork, vbzrx, accounts, wrapper):
+
+def test_events(requireMainnetFork, bzrx, vbzrx, chain, accounts, wrapper):
     account1 = accounts[4]
+    tx1 = vbzrx.transfer(account1, INITIAL_LP_TOKEN_ACCOUNT_AMOUNT, {"from": vbzrxMajorAddress})
+    vbzrx.approve(wrapper, vbzrx.balanceOf(account1), {"from": account1})
+    depositAmount = vbzrx.balanceOf(account1);
+    tx2 = wrapper.deposit(depositAmount, {"from": account1})
+    depositEvent = tx2.events['Deposit']
+    assert depositEvent['value'] == INITIAL_LP_TOKEN_ACCOUNT_AMOUNT
+    tx3 = wrapper.exit({"from": account1})
+    withdrawal = tx3.events['Withdrawal']
+    assert withdrawal['value'] == INITIAL_LP_TOKEN_ACCOUNT_AMOUNT
+
+
+def test_transfer(requireMainnetFork, bzrx, vbzrx, chain, accounts, wrapper):
+    account1 = accounts[5]
+    account2 = accounts[6]
+    tx1 = vbzrx.transfer(account1, INITIAL_LP_TOKEN_ACCOUNT_AMOUNT, {"from": vbzrxMajorAddress})
+    vbzrx.approve(wrapper, vbzrx.balanceOf(account1), {"from": account1})
+    depositAmount = vbzrx.balanceOf(account1);
+    wrapper.deposit(depositAmount, {"from": account1})
+    balanceBefore1 = bzrx.balanceOf(account1);
+
+    wrapper.transfer(account2, depositAmount / 2, {"from": account1})
+    chain.sleep(60 * 60 * 24)
+    chain.mine()
+    assert abs(wrapper.claimable(account2) - wrapper.claimable(account1)) / 1e18 < 5e-6
+    wrapper.claim({"from": account1})
+    chain.sleep(60 * 60 * 24)
+    chain.mine()
+    wrapper.exit({"from": account2})
+    wrapper.exit({"from": account1})
+    assert abs((bzrx.balanceOf(account1)) - balanceBefore1 - bzrx.balanceOf(account2)) / 1e18 < 5e-6
+
+
+def test_deposit_more_than_have(requireMainnetFork, vbzrx, accounts, wrapper):
+    account1 = accounts[5]
     vbzrx.transfer(account1, INITIAL_LP_TOKEN_ACCOUNT_AMOUNT, {"from": vbzrxMajorAddress})
-    vbzrx.approve(wrapper, vbzrx.balanceOf(account1)+1, {"from": account1})
+    vbzrx.approve(wrapper, vbzrx.balanceOf(account1) + 1, {"from": account1})
     with reverts("insufficient-balance"):
-        wrapper.deposit(vbzrx.balanceOf(account1)+1, {"from": account1})
+        wrapper.deposit(vbzrx.balanceOf(account1) + 1, {"from": account1})
+
 
 def test_deposit_more_than_approved(requireMainnetFork, vbzrx, accounts, wrapper):
-    account1 = accounts[4]
+    account1 = accounts[5]
     vbzrx.transfer(account1, INITIAL_LP_TOKEN_ACCOUNT_AMOUNT, {"from": vbzrxMajorAddress})
-    vbzrx.approve(wrapper, vbzrx.balanceOf(account1)-1, {"from": account1})
+    vbzrx.approve(wrapper, vbzrx.balanceOf(account1) - 1, {"from": account1})
     with reverts("insufficient-allowance"):
         wrapper.deposit(vbzrx.balanceOf(account1), {"from": account1})
 
+def test_transfer_multiple_deposit_withdraw(requireMainnetFork, bzrx, vbzrx, chain, accounts, wrapper):
+    for i in [1, 3]:
+        account1 = accounts[i]
+        vBzrxBalanceBefore1 = vbzrx.balanceOf(account1)
+        vbzrx.transfer(account1, INITIAL_LP_TOKEN_ACCOUNT_AMOUNT, {"from": vbzrxMajorAddress})
+        vbzrx.approve(wrapper, vbzrx.balanceOf(account1), {"from": account1})
+        depositAmount = vbzrx.balanceOf(account1);
+        #assert False
+        for i in range(5):
+            wrapper.deposit(depositAmount/5, {"from": account1})
+            chain.sleep(60 * 60 * 24)
+            chain.mine()
+            assert wrapper.claimable(account1) > 0
+            wrapper.claim({"from": account1})
 
-#TODO events
+        for i in range(5):
+            wrapper.withdraw(depositAmount/5, {"from": account1})
+            chain.sleep(60 * 60 * 24)
+            chain.mine()
+            assert wrapper.claimable(account1) > 0
+    for i in [1, 3]:
+        account1 = accounts[i]
+        wrapper.claim({"from": account1})
+
+
+def test_transfer_multiuser_withdraw1(requireMainnetFork, bzrx, vbzrx, chain, accounts, wrapper):
+    for i in [1, 3, 5, 7]:
+        account1 = accounts[i]
+        account2 = accounts[i + 1];
+        vbzrx.transfer(account1, INITIAL_LP_TOKEN_ACCOUNT_AMOUNT, {"from": vbzrxMajorAddress})
+        depositAmount = vbzrx.balanceOf(account1)/2;
+        vbzrx.transfer(account2, depositAmount, {"from": account1})
+        vbzrx.approve(wrapper, vbzrx.balanceOf(account1), {"from": account1})
+        vbzrx.approve(wrapper, vbzrx.balanceOf(account2), {"from": account2})
+
+        wrapper.deposit(depositAmount/2, {"from": account1})
+        wrapper.deposit(depositAmount/2, {"from": account2})
+        wrapper.deposit(depositAmount/2, {"from": account1})
+        wrapper.deposit(depositAmount/2, {"from": account2})
+        chain.sleep(60 * 60 * 24)
+        chain.mine()
+        assert wrapper.claimable(account1) > 0
+        assert wrapper.claimable(account2) > 0
+        wrapper.withdraw(wrapper.balanceOf(account2), {"from": account2})
+        assert wrapper.claimable(account2) > 0
+        wrapper.withdraw(wrapper.balanceOf(account1), {"from": account1})
+        assert wrapper.claimable(account1) > 0
+
+
+def test_transfer_multiuser_withdraw2(requireMainnetFork, bzrx, vbzrx, chain, accounts, wrapper):
+    for i in [1, 3, 5, 7]:
+        account1 = accounts[i]
+        account2 = accounts[i + 1];
+        tx1 = vbzrx.transfer(account1, INITIAL_LP_TOKEN_ACCOUNT_AMOUNT, {"from": vbzrxMajorAddress})
+        vbzrx.approve(wrapper, vbzrx.balanceOf(account1), {"from": account1})
+        depositAmount = vbzrx.balanceOf(account1);
+        wrapper.deposit(depositAmount, {"from": account1})
+        wrapper.transfer(account2, depositAmount / 2, {"from": account1})
+        chain.sleep(60 * 60 * 24)
+        chain.mine()
+        wrapper.claim({"from": account1})
+        chain.sleep(60 * 60 * 24)
+        chain.mine()
+        assert wrapper.claimable(account1) > 0
+        assert wrapper.claimable(account2) > 0
+        wrapper.withdraw(wrapper.balanceOf(account2), {"from": account2})
+        assert wrapper.claimable(account2) > 0
+        wrapper.withdraw(wrapper.balanceOf(account1), {"from": account1})
+        assert wrapper.claimable(account1) > 0
+
+def test_transfer_multiuser_exit(requireMainnetFork, bzrx, vbzrx, chain, accounts, wrapper):
+    for i in [1, 3, 5, 7]:
+        account1 = accounts[i]
+        account2 = accounts[i + 1];
+        tx1 = vbzrx.transfer(account1, INITIAL_LP_TOKEN_ACCOUNT_AMOUNT, {"from": vbzrxMajorAddress})
+        vbzrx.approve(wrapper, vbzrx.balanceOf(account1), {"from": account1})
+        depositAmount = vbzrx.balanceOf(account1);
+        wrapper.deposit(depositAmount, {"from": account1})
+        wrapper.transfer(account2, depositAmount / 2, {"from": account1})
+        chain.sleep(60 * 60 * 24)
+        chain.mine()
+        wrapper.claim({"from": account1})
+        chain.sleep(60 * 60 * 24)
+        chain.mine()
+        wrapper.exit({"from": account2})
+        wrapper.exit({"from": account1})
+
+def test_user_able_to_claim_before_vesting_last_claim_timestamp(requireMainnetFork, bzrx, vbzrx, chain, accounts,
+                                                                wrapper):
+    account1 = accounts[4]
+    vBzrxBalanceBefore1 = vbzrx.balanceOf(account1)
+    tx1 = vbzrx.transfer(account1, INITIAL_LP_TOKEN_ACCOUNT_AMOUNT, {"from": vbzrxMajorAddress})
+    vbzrx.approve(wrapper, vbzrx.balanceOf(account1), {"from": account1})
+    depositAmount = vbzrx.balanceOf(account1);
+    tx2 = wrapper.deposit(depositAmount, {"from": account1})
+    balanceBefore1 = bzrx.balanceOf(account1)
+    yearSeconds = 60 * 60 * 24 * 365;
+    # pass 1 year
+    chain.sleep(yearSeconds)
+    chain.mine()
+    wrapper.claim({"from": account1});
+    assert bzrx.balanceOf(account1) > balanceBefore1
+    assert wrapper.claimable(account1) == 0
+
+    # sleep up to vestingLastClaimTimestamp
+    chain.sleep((vbzrx.vestingLastClaimTimestamp() - chain.time()) - 10)
+    chain.mine()
+    balanceBefore2 = bzrx.balanceOf(account1)
+    assert wrapper.claimable(account1) > 0
+    tx3 = wrapper.exit({"from": account1})
+    assert bzrx.balanceOf(account1) > balanceBefore2
+    assert vbzrx.balanceOf(account1) == INITIAL_LP_TOKEN_ACCOUNT_AMOUNT + vBzrxBalanceBefore1
+
+
+def test_user_unable_to_claim_after_vesting_last_claim_timestamp(requireMainnetFork, bzrx, vbzrx, chain, accounts,
+                                                                 wrapper):
+    account1 = accounts[4]
+    tx1 = vbzrx.transfer(account1, INITIAL_LP_TOKEN_ACCOUNT_AMOUNT, {"from": vbzrxMajorAddress})
+    vbzrx.approve(wrapper, vbzrx.balanceOf(account1), {"from": account1})
+    depositAmount = vbzrx.balanceOf(account1);
+    tx2 = wrapper.deposit(depositAmount, {"from": account1})
+    balanceBefore1 = bzrx.balanceOf(account1)
+
+    # sleep up to vestingLastClaimTimestamp
+    if(vbzrx.vestingLastClaimTimestamp() < chain.time()):
+        chain.sleep((vbzrx.vestingLastClaimTimestamp() - chain.time()) + 1)
+    chain.mine()
+    assert wrapper.claimable(account1) == 0
+    wrapper.claim({"from": account1});
+    assert bzrx.balanceOf(account1) == balanceBefore1
+
+
+def test_user_unable_to_deposit_after_vesting_last_claim_timestamp(requireMainnetFork, vbzrx, accounts, wrapper):
+    account1 = accounts[8]
+    tx1 = vbzrx.transfer(account1, INITIAL_LP_TOKEN_ACCOUNT_AMOUNT, {"from": vbzrxMajorAddress})
+    vbzrx.approve(wrapper, vbzrx.balanceOf(account1), {"from": account1})
+    vbzrxBalanceBefore1 = vbzrx.balanceOf(account1)
+    wrapperBalanceBefore1 = vbzrx.balanceOf(account1)
+    depositAmount = vbzrx.balanceOf(account1);
+    tx2 = wrapper.deposit(depositAmount, {"from": account1})
+    assert vbzrx.balanceOf(account1) == vbzrxBalanceBefore1
+    assert wrapper.balanceOf(account1) == wrapperBalanceBefore1
+
+
+


### PR DESCRIPTION
We can be use HelperProxy directly
impl = VBZRXWrapper.deploy({"from": accounts[0]})
proxy = HelperProxy.deploy(impl, {'from': accounts[0]})
wrapper = Contract.from_abi("wrapper", address=proxy, abi=VBZRXWrapper.abi, owner=accounts[0])

tests  passed + added few validations for switch implementation