### PR TITLE
different verison of openzeppelin. planning to remove openzeppelin fo…

### DIFF
--- a/brownie-config.yaml
+++ b/brownie-config.yaml
@@ -39,7 +39,8 @@ compiler:
             enabled: true
             runs: 200
         remappings: 
-            - "@openzeppelin=./node_modules/@openzeppelin/"
+            - "@openzeppelin-3.4.0=./node_modules/openzeppelin-3.4.0"
+            - "@openzeppelin-2.5.0=./node_modules/openzeppelin-2.5.0"
 
 console:
     show_colors: true

--- a/contracts/farm/BGovToken.sol
+++ b/contracts/farm/BGovToken.sol
@@ -2,8 +2,8 @@
 
 pragma solidity 0.6.12;
 
-import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
-import "@openzeppelin/contracts/access/Ownable.sol";
+import "@openzeppelin-3.4.0/token/ERC20/ERC20.sol";
+import "@openzeppelin-3.4.0/access/Ownable.sol";
 
 
 // BGovToken with Governance.

--- a/contracts/farm/FeeExtractAndDistribute_BSC.sol
+++ b/contracts/farm/FeeExtractAndDistribute_BSC.sol
@@ -6,8 +6,8 @@
 pragma solidity 0.6.12;
 pragma experimental ABIEncoderV2;
 
-import "@openzeppelin/contracts/token/ERC20/SafeERC20.sol";
-import "@openzeppelin/contracts/math/SafeMath.sol";
+import "@openzeppelin-3.4.0/token/ERC20/SafeERC20.sol";
+// import "@openzeppelin-3.4.0/math/SafeMath.sol";
 import "./interfaces/Upgradeable.sol";
 import "./interfaces/IWethERC20.sol";
 import "./interfaces/IUniswapV2Router.sol";

--- a/contracts/farm/FeeExtractAndDistribute_BSC.sol
+++ b/contracts/farm/FeeExtractAndDistribute_BSC.sol
@@ -7,7 +7,6 @@ pragma solidity 0.6.12;
 pragma experimental ABIEncoderV2;
 
 import "@openzeppelin-3.4.0/token/ERC20/SafeERC20.sol";
-// import "@openzeppelin-3.4.0/math/SafeMath.sol";
 import "./interfaces/Upgradeable.sol";
 import "./interfaces/IWethERC20.sol";
 import "./interfaces/IUniswapV2Router.sol";

--- a/contracts/farm/GovToken.sol
+++ b/contracts/farm/GovToken.sol
@@ -2,9 +2,9 @@
 
 pragma solidity 0.6.12;
 
-import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
-import "@openzeppelin/contracts/token/ERC20/SafeERC20.sol";
-import "@openzeppelin/contracts/access/Ownable.sol";
+import "@openzeppelin-3.4.0/token/ERC20/ERC20.sol";
+import "@openzeppelin-3.4.0/token/ERC20/SafeERC20.sol";
+import "@openzeppelin-3.4.0/access/Ownable.sol";
 
 
 // polygon (PGOV): 0xd5d84e75f48E75f01fb2EB6dFD8eA148eE3d0FEb

--- a/contracts/farm/MasterChef_BSC.sol
+++ b/contracts/farm/MasterChef_BSC.sol
@@ -3,9 +3,9 @@ pragma experimental ABIEncoderV2;
 
 /// SPDX-License-Identifier: MIT
 
-import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
-import "@openzeppelin/contracts/token/ERC20/SafeERC20.sol";
-import "@openzeppelin/contracts/math/SafeMath.sol";
+import "@openzeppelin-3.4.0/token/ERC20/IERC20.sol";
+import "@openzeppelin-3.4.0/token/ERC20/SafeERC20.sol";
+// import "@openzeppelin-3.4.0/math/SafeMath.sol";
 import "./interfaces/Upgradeable.sol";
 import "./GovToken.sol";
 import "./MintCoordinator_BSC.sol";

--- a/contracts/farm/MasterChef_BSC.sol
+++ b/contracts/farm/MasterChef_BSC.sol
@@ -5,7 +5,6 @@ pragma experimental ABIEncoderV2;
 
 import "@openzeppelin-3.4.0/token/ERC20/IERC20.sol";
 import "@openzeppelin-3.4.0/token/ERC20/SafeERC20.sol";
-// import "@openzeppelin-3.4.0/math/SafeMath.sol";
 import "./interfaces/Upgradeable.sol";
 import "./GovToken.sol";
 import "./MintCoordinator_BSC.sol";

--- a/contracts/farm/MasterChef_Polygon.sol
+++ b/contracts/farm/MasterChef_Polygon.sol
@@ -3,9 +3,9 @@ pragma experimental ABIEncoderV2;
 
 /// SPDX-License-Identifier: MIT
 
-import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
-import "@openzeppelin/contracts/token/ERC20/SafeERC20.sol";
-import "@openzeppelin/contracts/math/SafeMath.sol";
+import "@openzeppelin-3.4.0/token/ERC20/IERC20.sol";
+import "@openzeppelin-3.4.0/token/ERC20/SafeERC20.sol";
+// import "@openzeppelin-3.4.0/math/SafeMath.sol";
 import "./interfaces/Upgradeable.sol";
 import "./GovToken.sol";
 import "./MintCoordinator_Polygon.sol";

--- a/contracts/farm/MasterChef_Polygon.sol
+++ b/contracts/farm/MasterChef_Polygon.sol
@@ -5,7 +5,6 @@ pragma experimental ABIEncoderV2;
 
 import "@openzeppelin-3.4.0/token/ERC20/IERC20.sol";
 import "@openzeppelin-3.4.0/token/ERC20/SafeERC20.sol";
-// import "@openzeppelin-3.4.0/math/SafeMath.sol";
 import "./interfaces/Upgradeable.sol";
 import "./GovToken.sol";
 import "./MintCoordinator_Polygon.sol";

--- a/contracts/farm/MintCoordinator_BSC.sol
+++ b/contracts/farm/MintCoordinator_BSC.sol
@@ -5,7 +5,7 @@
 
 pragma solidity 0.6.12;
 
-import "@openzeppelin/contracts/access/Ownable.sol";
+import "@openzeppelin-3.4.0/access/Ownable.sol";
 
 
 interface GovTokenLike {

--- a/contracts/farm/MintCoordinator_Polygon.sol
+++ b/contracts/farm/MintCoordinator_Polygon.sol
@@ -5,8 +5,8 @@
 
 pragma solidity 0.6.12;
 
-import "@openzeppelin/contracts/token/ERC20/SafeERC20.sol";
-import "@openzeppelin/contracts/access/Ownable.sol";
+import "@openzeppelin-3.4.0/token/ERC20/SafeERC20.sol";
+import "@openzeppelin-3.4.0/access/Ownable.sol";
 
 
 interface GovTokenLike {

--- a/contracts/farm/Proxy.sol
+++ b/contracts/farm/Proxy.sol
@@ -2,7 +2,7 @@ pragma solidity 0.6.12;
 
 /// SPDX-License-Identifier: MIT
 
-import "@openzeppelin/contracts/utils/Address.sol";
+import "@openzeppelin-3.4.0/utils/Address.sol";
 import "./interfaces/Upgradeable.sol";
 
 

--- a/contracts/farm/interfaces/IMasterChefAdmin.sol
+++ b/contracts/farm/interfaces/IMasterChefAdmin.sol
@@ -1,5 +1,5 @@
 pragma solidity 0.6.12;
-import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import "@openzeppelin-3.4.0/token/ERC20/IERC20.sol";
 import "./IMasterChef.sol";
 pragma experimental ABIEncoderV2;
 

--- a/contracts/farm/interfaces/IWethERC20.sol
+++ b/contracts/farm/interfaces/IWethERC20.sol
@@ -5,7 +5,7 @@
 
 pragma solidity >=0.6.0 <0.7.0;
 
-import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import "@openzeppelin-3.4.0/token/ERC20/IERC20.sol";
 import "./IWeth.sol";
 
 

--- a/contracts/farm/interfaces/Upgradeable.sol
+++ b/contracts/farm/interfaces/Upgradeable.sol
@@ -5,7 +5,7 @@
 
 pragma solidity >=0.6.0 <0.7.0;
 
-import "@openzeppelin/contracts/access/Ownable.sol";
+import "@openzeppelin-3.4.0/access/Ownable.sol";
 
 
 contract Upgradeable is Ownable {

--- a/contracts/helpers/HelperImpl.sol
+++ b/contracts/helpers/HelperImpl.sol
@@ -8,8 +8,8 @@ pragma experimental ABIEncoderV2;
 
 /// SPDX-License-Identifier: MIT
 
-import "@openzeppelin/contracts/access/Ownable.sol";
-import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import "@openzeppelin-3.4.0/access/Ownable.sol";
+import "@openzeppelin-3.4.0/token/ERC20/IERC20.sol";
 import "./IToken.sol";
 import "./IBZx.sol";
 import "../feeds/IPriceFeeds.sol";

--- a/contracts/helpers/HelperProxy.sol
+++ b/contracts/helpers/HelperProxy.sol
@@ -8,8 +8,8 @@ pragma solidity ^0.7.6;
 
 /// SPDX-License-Identifier: MIT
 
-import "@openzeppelin/contracts/access/Ownable.sol";
-import "@openzeppelin/contracts/utils/Address.sol";
+import "@openzeppelin-3.4.0/access/Ownable.sol";
+import "@openzeppelin-3.4.0/utils/Address.sol";
 
 
 contract HelperProxy is Ownable {

--- a/contracts/protocoltoken/migrations/BZRXv2Converter.sol
+++ b/contracts/protocoltoken/migrations/BZRXv2Converter.sol
@@ -5,8 +5,8 @@
 // SPDX-License-Identifier: Apache License, Version 2.0.
 pragma solidity 0.6.12;
 
-import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
-import "@openzeppelin/contracts/access/Ownable.sol";
+import "@openzeppelin-3.4.0/token/ERC20/ERC20.sol";
+import "@openzeppelin-3.4.0/access/Ownable.sol";
 import "./VBZRXv2VestingToken.sol";
 import "./BZRXv2Token.sol";
 

--- a/contracts/protocoltoken/migrations/BZRXv2Token.sol
+++ b/contracts/protocoltoken/migrations/BZRXv2Token.sol
@@ -2,8 +2,8 @@
 
 pragma solidity 0.6.12;
 
-import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
-import "@openzeppelin/contracts/access/Ownable.sol";
+import "@openzeppelin-3.4.0/token/ERC20/ERC20.sol";
+import "@openzeppelin-3.4.0/access/Ownable.sol";
 
 contract BZRXv2Token is ERC20("BZRXv2 Token", "BZRXv2"), Ownable {
     function mint(address _to, uint256 _amount) public onlyOwner {

--- a/contracts/protocoltoken/migrations/IVestingToken.sol
+++ b/contracts/protocoltoken/migrations/IVestingToken.sol
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: Apache License, Version 2.0.
 pragma solidity 0.6.12;
 
-import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import "@openzeppelin-3.4.0/token/ERC20/IERC20.sol";
 
 interface IVestingToken is IERC20 {
     function claim() external;

--- a/contracts/protocoltoken/migrations/Upgradeable_6.sol
+++ b/contracts/protocoltoken/migrations/Upgradeable_6.sol
@@ -6,7 +6,7 @@
 // SPDX-License-Identifier: Apache License, Version 2.0.
 pragma solidity >=0.6.0 <=0.6.12;
 
-import "@openzeppelin/contracts/access/Ownable.sol";
+import "@openzeppelin-3.4.0/access/Ownable.sol";
 
 contract Upgradeable_6 is Ownable {
     address public implementation;

--- a/contracts/protocoltoken/migrations/VBZRXv2VestingToken.sol
+++ b/contracts/protocoltoken/migrations/VBZRXv2VestingToken.sol
@@ -5,8 +5,8 @@
 // SPDX-License-Identifier: Apache License, Version 2.0.
 pragma solidity 0.6.12;
 
-import "@openzeppelin/contracts/math/SafeMath.sol";
-import "@openzeppelin/contracts/token/ERC20/SafeERC20.sol";
+import "@openzeppelin-3.4.0/math/SafeMath.sol";
+import "@openzeppelin-3.4.0/token/ERC20/SafeERC20.sol";
 import "./IVestingToken.sol";
 import "./Upgradeable_6.sol";
 

--- a/interfaces/IToken.sol
+++ b/interfaces/IToken.sol
@@ -5,7 +5,7 @@
 
 pragma solidity >=0.6.0 <0.8.0;
 pragma experimental ABIEncoderV2;
-import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import "@openzeppelin-3.4.0/token/ERC20/IERC20.sol";
 
 // import "contracts/interfaces/IERC20.sol";
 /// SPDX-License-Identifier: Apache License, Version 2.0.

--- a/package.json
+++ b/package.json
@@ -14,9 +14,11 @@
     "url": "https://github.com/bZxNetwork/contractsV2/issues"
   },
   "devDependencies": {
-    "@openzeppelin/contracts": "^3.3.0",
+    "@openzeppelin/contracts": "^3.4.1",
     "cross-env": "^7.0.2",
     "husky": "^4.2.5",
+    "openzeppelin-2.5.0": "npm:@openzeppelin/contracts@^2.5.0",
+    "openzeppelin-3.4.0": "npm:@openzeppelin/contracts@^3.4.0",
     "prettier": "^2.0.5",
     "prettier-plugin-solidity": "^1.0.0-alpha.49",
     "solhint": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,6 @@
     "url": "https://github.com/bZxNetwork/contractsV2/issues"
   },
   "devDependencies": {
-    "@openzeppelin/contracts": "^3.4.1",
     "cross-env": "^7.0.2",
     "husky": "^4.2.5",
     "openzeppelin-2.5.0": "npm:@openzeppelin/contracts@^2.5.0",


### PR DESCRIPTION
…lder and use library

The plan is to remove `openzeppelin` folder which is little modified copy. either create a wrapper or use pure library.  This will allow us more easily upgrade solidity and unify solidity versions 